### PR TITLE
Remove reboot command from halium-install

### DIFF
--- a/halium-install
+++ b/halium-install
@@ -200,5 +200,5 @@ echo -n "cleaning up on device ... "
 cleanup_device
 echo "[done]"
 
-echo "rebooting device"
-adb reboot
+echo "All done! Now you can use 'adb shell' to get a shell to the recovery, or"
+echo "simply reboot your device to start Halium."


### PR DESCRIPTION
The automatic reboot at the end of halium-install has been a pain in my side for far too long. I propose removing it and replacing it with a hint of what to do next, so that it's possible to do things like resetting the root user's password without having to boot into recovery a second time.