### PR TITLE
Make system.img the right size for the device

### DIFF
--- a/halium-install
+++ b/halium-install
@@ -44,7 +44,8 @@ convert_android_img()
 		simg2img $SYSIMG $WORKDIR/system.img.raw
 		mkdir $TMPMOUNT
 		mount -t ext4 -o loop $WORKDIR/system.img.raw $TMPMOUNT
-		make_ext4fs -l 160M $WORKDIR/system.img $TMPMOUNT
+		IMAGE_SIZE=`wc -c < $SYSIMG`
+		make_ext4fs -l $IMAGE_SIZE $WORKDIR/system.img $TMPMOUNT
 		SYSIMAGE=$WORKDIR/system.img
 	else
 		SYSIMAGE=$SYSIMG


### PR DESCRIPTION
In some builds (especially very early / testing ones), the Android `system.img` can take up a lot of space. Rootstock-touch-install doesn't account for this and just makes a 160MB one no matter what. This patch uses `wc` to get the size of the sparse `system.img` and makes the contiguous image this size. This way we won't run into strange errors such as `error: ext4_allocate_best_fit_partial: failed to allocate 48 blocks, out of space?`.