### PR TITLE
halium-install: option for injecting ssh-key into rootfs

### DIFF
--- a/halium-install
+++ b/halium-install
@@ -98,7 +98,8 @@ usage()
 	-h|--help		this message
 	-c|--custom		path to customization tarball (needs to be tar.xz)
 	-k|--keep-userdata	do not wipe user data on device
-	-w|--wipe-file		absolute path of a file inside the image to wipe (empty)"
+	-w|--wipe-file		absolute path of a file inside the image to wipe (empty)
+	-s|--ssh-key		path to ssh public key for root access"
 	exit 1
 }
 
@@ -117,6 +118,9 @@ while [ $# -gt 0 ]; do
 			;;
 		-w|--wipe-file)
 			[ -n "$2" ] && WIPE_PATH=$2 shift || usage
+			;;
+		-s|--ssh-key)
+			[ -n "$2" ] && SSH_KEY=$2 shift || usage
 			;;
 	esac
 	shift
@@ -189,6 +193,14 @@ echo -n "unpacking rootfs tarball to system-image ... "
 do_shell "cd /cache/system && zcat /recovery/$TARBALL | tar xf -"
 do_shell "[ -e /cache/system/SWAP.swap ] && mv /cache/system/SWAP.swap /data/SWAP.img"
 echo "[done]"
+
+if [ ! -z "$SSH_KEY" ]; then
+	echo "injecting ssh key for root access ... "
+	do_shell "mkdir -m 0700 -p /cache/system/root/.ssh"
+	adb push $SSH_KEY /cache/system/root/.ssh/authorized_keys
+	do_shell "chmod 0644 /cache/system/root/.ssh/authorized_keys"
+	echo "[done]"
+fi
 
 echo -n "adding android system image to installation ... "
 convert_android_img


### PR DESCRIPTION
This will copy a ssh public key given on the command line to rootfs /root/.ssh/authorized_keys 